### PR TITLE
Use a changelog template

### DIFF
--- a/.github/workflows/build_db.yml
+++ b/.github/workflows/build_db.yml
@@ -32,7 +32,9 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
         name: changelog
-        path: sqldiff.txt
+        path: |
+          changelog.txt
+          sqldiff.txt
         if-no-files-found: error
     - name: Build JSON DB
       if: always()
@@ -55,6 +57,6 @@ jobs:
         with:
           name: ${{ needs.build_db.outputs.dbname }}
           tag_name: ${{ needs.build_db.outputs.dbname }}
-          body_path: 'changelog/sqldiff.txt'
+          body_path: 'changelog/changelog.txt'
           files: 'uscis-db/*.db'
           fail_on_unmatched_files: true

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # USCIS Dataset
 
+[![Build USCIS DB](https://github.com/jzebedee/uscis/actions/workflows/build_db.yml/badge.svg)](https://github.com/jzebedee/uscis/actions/workflows/build_db.yml)
+
 Daily datasets of USCIS form processing times
 
 ## About
@@ -15,6 +17,10 @@ The dataset releases are produced on a daily cron schedule that scrapes the USCI
 The raw JSON results are also collected into a [SQLite archive](https://www.sqlite.org/sqlar.html) and published as an artifact, in the case of debugging or if there's additional information to extract. These artifacts are _not_ a permanent collection and will be removed eventually based on the [artifact retention period](https://docs.github.com/en/organizations/managing-organization-settings/configuring-the-retention-period-for-github-actions-artifacts-and-logs-in-your-organization).
 
 ## Changelog
+
+### v0.3 - 2023-07-29
+
+* Release notes are now generated with `sqldiff` output to compare daily changes
 
 ### v0.2 - 2022-05-05
 

--- a/build_db.sh
+++ b/build_db.sh
@@ -28,5 +28,8 @@ brew update && brew install sqlite sqldiff
 # rename to current date
 mv uscis.db "$(date +"%F").db"
 
-# generate changelog
+# generate raw sqldiff
 sqldiff prev/*.db *.db > sqldiff.txt
+
+# generate changelog
+printf "$(<changelog-template.txt)" "$(basename prev/*.db .db)" "$(basename *.db .db)" "$(<sqldiff.txt)" > changelog.txt

--- a/changelog-template.txt
+++ b/changelog-template.txt
@@ -1,0 +1,5 @@
+The following changes occurred between %s and %s:
+
+```sql
+%s
+```


### PR DESCRIPTION
Make the release notes prettier with a markdown template instead of just using raw `sqldiff` output