### PR TITLE
Truncate changelog body to handle long sqldiffs

### DIFF
--- a/build_db.sh
+++ b/build_db.sh
@@ -32,4 +32,11 @@ mv uscis.db "$(date +"%F").db"
 sqldiff prev/*.db *.db > sqldiff.txt
 
 # generate changelog
-printf "$(<changelog-template.txt)" "$(basename prev/*.db .db)" "$(basename *.db .db)" "$(<sqldiff.txt)" > changelog.txt
+sqldiff=$(<sqldiff.txt)
+max_diff_length=124000
+if [ $(wc -c <<< $sqldiff) -gt $max_diff_length ]
+then
+    printf -v sqldiff '%.*s...\n\nTruncated for length' $max_diff_length "$(<sqldiff.txt)"
+fi
+
+printf "$(<changelog-template.txt)" "$(basename prev/*.db .db)" "$(basename *.db .db)" "$sqldiff" > changelog.txt


### PR DESCRIPTION
Apparently we can only fit 125k chars in a release body:

```
GitHub release failed with status: 422
[{"resource":"Release","code":"custom","field":"body","message":"body is too long (maximum is 125000 characters)"}]
```