### PR TITLE
Explicitly cast readfile to text affinity

### DIFF
--- a/populate-form-types-offices-template.sql
+++ b/populate-form-types-offices-template.sql
@@ -8,7 +8,7 @@ WITH form_offices_new AS (
       (response ->> '$.data.form_offices.form_name') AS form_name,
       (response ->> '$.data.form_offices.form_type') AS form_type,
       (response -> '$.data.form_offices.offices') AS offices
-    FROM (SELECT json(readfile('%s')) AS response)
+    FROM (SELECT json(CAST(readfile('%s') AS TEXT)) AS response)
   ), json_each(offices)
 ), form_offices_old AS (
   SELECT

--- a/populate-form-types-template.sql
+++ b/populate-form-types-template.sql
@@ -2,7 +2,7 @@ WITH response_types_json AS (
   SELECT
     json_each.value
   FROM(
-    (SELECT json(readfile('%s')) -> '$.data.form_types.subtypes' AS types)
+    (SELECT json(CAST(readfile('%s') AS TEXT)) -> '$.data.form_types.subtypes' AS types)
   ), json_each(types)
 ), response_types AS (
   SELECT

--- a/populate-forms-table.sql
+++ b/populate-forms-table.sql
@@ -3,4 +3,4 @@ SELECT
  (form ->> '$.form_name') AS name,
  (form ->> '$.form_description_en') AS description_en,
  (form ->> '$.form_description_es') AS description_es
-FROM (SELECT json_each.value AS form FROM (SELECT (readfile('response-forms.json') -> '$.data.forms.forms') as forms), json_each(forms));
+FROM (SELECT json_each.value AS form FROM (SELECT json(CAST(readfile('response-forms.json') AS TEXT) -> '$.data.forms.forms') as forms), json_each(forms));

--- a/populate-offices-table-template.sql
+++ b/populate-offices-table-template.sql
@@ -2,4 +2,4 @@ INSERT OR IGNORE INTO offices
 SELECT
  (office ->> '$.office_code') AS code,
  (office ->> '$.office_description') AS description
-FROM (SELECT json_each.value AS office FROM (SELECT (json(readfile('%s')) -> '$.data.form_offices.offices') as offices), json_each(offices));
+FROM (SELECT json_each.value AS office FROM (SELECT (json(CAST(readfile('%s') AS TEXT)) -> '$.data.form_offices.offices') as offices), json_each(offices));

--- a/populate-processing-time-template.sql
+++ b/populate-processing-time-template.sql
@@ -17,7 +17,7 @@ WITH args1 AS (
   FROM args2
 ), json_doc AS (
   SELECT
-    json(readfile(filename)) AS doc,
+    json(CAST(readfile(filename) AS TEXT)) AS doc,
     office_code AS true_office_code
   FROM args3
 ), pt_doc AS (


### PR DESCRIPTION
Note: SQLite 3.45.0's jsonb handling broke us because readfile returns a blob which the default json functions interpret as well-formed JSONB and attempt to parse.

https://www.sqlite.org/releaselog/3_45_0.html